### PR TITLE
Fixes `No such file or directory: 'logs/development.log'` issue

### DIFF
--- a/feature_gate/clients/posthog_api_client.py
+++ b/feature_gate/clients/posthog_api_client.py
@@ -33,6 +33,10 @@ class PosthogAPIClient:
       self.project_id = project_id
 
     bind_contextvars(klass="PosthogAPIClient", project_id=project_id)
+    project_root = os.environ.get('PROJECT_ROOT', '/srv')
+    logs_dir_path = Path(project_root, 'logs')
+    logs_dir_path.mkdir(parents=True, exist_ok=True)
+    log_file = logs_dir_path.joinpath('development').with_suffix('.log').open('wt')
     structlog.configure(
       processors=[
         merge_contextvars,
@@ -41,9 +45,7 @@ class PosthogAPIClient:
         structlog.processors.dict_tracebacks,
         structlog.processors.JSONRenderer(),
       ],
-      logger_factory=structlog.WriteLoggerFactory(
-        file=Path("logs").joinpath("development").with_suffix(".log").open("wt")
-      ),
+      logger_factory=structlog.WriteLoggerFactory(file=log_file),
     )
     self.logger = structlog.get_logger()
 

--- a/feature_gate/clients/posthog_api_client.py
+++ b/feature_gate/clients/posthog_api_client.py
@@ -33,7 +33,7 @@ class PosthogAPIClient:
       self.project_id = project_id
 
     bind_contextvars(klass="PosthogAPIClient", project_id=project_id)
-    project_root = os.environ.get('PROJECT_ROOT', '.')
+    project_root = os.path.abspath(os.getenv('PROJECT_ROOT', '.'))
     logs_dir_path = Path(project_root, 'logs')
     logs_dir_path.mkdir(parents=True, exist_ok=True)
     log_file = logs_dir_path.joinpath('development').with_suffix('.log').open('wt')

--- a/feature_gate/clients/posthog_api_client.py
+++ b/feature_gate/clients/posthog_api_client.py
@@ -33,7 +33,7 @@ class PosthogAPIClient:
       self.project_id = project_id
 
     bind_contextvars(klass="PosthogAPIClient", project_id=project_id)
-    project_root = os.environ.get('PROJECT_ROOT', '/srv')
+    project_root = os.environ.get('PROJECT_ROOT', '.')
     logs_dir_path = Path(project_root, 'logs')
     logs_dir_path.mkdir(parents=True, exist_ok=True)
     log_file = logs_dir_path.joinpath('development').with_suffix('.log').open('wt')


### PR DESCRIPTION
In certain environments we've run into issues with proper permissions to write logs. This normalizes logs to be set relative to `PROJECT_ROOT` environment variable. If that is not available it falls back to the current working directory.