### PR TITLE
fix KeyError by providing empty dict as default value

### DIFF
--- a/feature_gate/clients/posthog_api_client.py
+++ b/feature_gate/clients/posthog_api_client.py
@@ -77,7 +77,7 @@ class PosthogAPIClient:
       return self._map_single_response("POST", path, response)
 
   def fetch_feature(self, key):
-    features = self.list_features()["data"]
+    features = self.list_features().get("data", {})
     for entry in features:
         if "key" in entry and entry["key"] == key:
             return entry

--- a/feature_gate/clients/posthog_api_client.py
+++ b/feature_gate/clients/posthog_api_client.py
@@ -77,7 +77,7 @@ class PosthogAPIClient:
       return self._map_single_response("POST", path, response)
 
   def fetch_feature(self, key):
-    features = self.list_features().get("data", {})
+    features = self.list_features().get("data", [])
     for entry in features:
         if "key" in entry and entry["key"] == key:
             return entry

--- a/tests/feature_gate/adapters/posthog_test.py
+++ b/tests/feature_gate/adapters/posthog_test.py
@@ -4,7 +4,7 @@ import requests
 from feature_gate.adapters.posthog import PosthogAdapter
 from feature_gate.client import Client, FeatureNotFound
 from feature_gate.feature import Feature
-from tests.fixtures.posthog_api_client.mocks import build_feature_from_mocks, mock_add_feature_funnel, mock_disable_feature_funnel, mock_enable_feature_funnel, mock_features_when_empty, mock_features_when_funnel, mock_funnel_is_disabled, mock_funnel_is_enabled, mock_remove_feature_funnel
+from tests.fixtures.posthog_api_client.mocks import build_feature_from_mocks, mock_add_feature_funnel, mock_disable_feature_funnel, mock_enable_feature_funnel, mock_features_when_empty, mock_features_when_error_returned, mock_features_when_funnel, mock_funnel_is_disabled, mock_funnel_is_enabled, mock_remove_feature_funnel
 from unittest.mock import patch
 
 def configured_client():
@@ -82,6 +82,15 @@ def test_is_enabled_raises_an_error_when_the_feature_does_not_exist():
   client = configured_client()
   feature = build_feature_from_mocks()
   with patch.object(requests, 'get', return_value=mock_features_when_empty()):
+    try:
+      resp = client.is_enabled(feature.key)
+    except FeatureNotFound as e:
+      assert str(e) == "Feature funnel_test not found"
+
+def test_is_enabled_raises_an_error_when_the_api_response_returns_an_error_status():
+  client = configured_client()
+  feature = build_feature_from_mocks()
+  with patch.object(requests, 'get', return_value=mock_features_when_error_returned()):
     try:
       resp = client.is_enabled(feature.key)
     except FeatureNotFound as e:

--- a/tests/fixtures/posthog_api_client/mocks.py
+++ b/tests/fixtures/posthog_api_client/mocks.py
@@ -81,3 +81,11 @@ def mock_funnel_is_disabled():
       return_value=load_response('funnel_is_disabled')
     )
   )
+
+def mock_features_when_error_returned():
+  return Mock(
+    status_code=500,
+    json=Mock(
+      return_value=load_response('get_features_when_empty')
+    )
+  )


### PR DESCRIPTION
This fixes `KeyError 'data'` errors.

This switches access for the dict to use `.get()` and supplies a default value `{}` when the 'data' key is not present.