### PR TITLE
use append mode when writing to logs

### DIFF
--- a/feature_gate/clients/posthog_api_client.py
+++ b/feature_gate/clients/posthog_api_client.py
@@ -36,7 +36,7 @@ class PosthogAPIClient:
     project_root = os.path.abspath(os.getenv('PROJECT_ROOT', '.'))
     logs_dir_path = Path(project_root, 'logs')
     logs_dir_path.mkdir(parents=True, exist_ok=True)
-    log_file = logs_dir_path.joinpath('development').with_suffix('.log').open('wt')
+    log_file = logs_dir_path.joinpath('development').with_suffix('.log').open('at')
     structlog.configure(
       processors=[
         merge_contextvars,


### PR DESCRIPTION
We ran into an issue with multiple processes potentially all writing to the same log and stepping on each other. This should remedy that problem.